### PR TITLE
Update PublisherId to bulldog68

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ Repository = "https://github.com/bulldog68/ComfyUI_FMJ"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = "bulldog63"
+PublisherId = "bulldog68"
 DisplayName = "ComfyUI_FMJ"
 Icon = ""


### PR DESCRIPTION
Change PublisherId in pyproject.toml from "bulldog63" to "bulldog68".
Motif : faire correspondre le PublisherId au login GitHub pour éviter les conflits avec le registre Comfy.
Fichier modifié : pyproject.toml
Commit : bf27503b75b58900c018f88c5e40aa3aae7390bb
Branche source : update-publisherid
Branche cible : main
